### PR TITLE
Big update

### DIFF
--- a/netlify/functions/main.ts
+++ b/netlify/functions/main.ts
@@ -21,7 +21,7 @@ export const handler: Handler = async (event) => {
   if (!body.message) {
     return {
       statusCode: 400,
-      body: JSON.stringify({ message: "Email message isn't provided" })
+      body: JSON.stringify({ message: "Message isn't provided" })
     }    
   }
 


### PR DESCRIPTION
There is no logic to check the message for the fact that it is an email, so just leave it as "Message isn't provided".